### PR TITLE
fix: remove max-width

### DIFF
--- a/src/CookiePolicyBanner/_cookie-policy-banner.scss
+++ b/src/CookiePolicyBanner/_cookie-policy-banner.scss
@@ -75,7 +75,6 @@ $small-font-size: 14px;
       margin: auto;
       color: $cookie-banner-text-color;
       text-align: center;
-      max-width: 800px;
       font-size: $small-font-size;
     }
 


### PR DESCRIPTION
Reduce vertical real estate usage by allowing the cookie policy text to be as wide as is needed