### PR TITLE
fix(color): Enable close button to pass a11y 3:1 contrast requirement.

### DIFF
--- a/src/CookiePolicyBanner/_cookie-policy-banner.scss
+++ b/src/CookiePolicyBanner/_cookie-policy-banner.scss
@@ -1,6 +1,6 @@
 $cookie-banner-background-color: #f2f8fd !default;
 $cookie-banner-text-color: #4e4e4e !default;
-$cookie-banner-cta-base: #0075b4 !default;
+$cookie-banner-cta-base: #19291F !default;
 $cookie-banner-cta-hover: #075683 !default;
 
 $font-family-sans-serif: Arial, sans-serif !default;


### PR DESCRIPTION
The same change https://github.com/edx/frontend-component-cookie-policy-banner/pull/289 with fixed commit message format to enable semantic-release to push it to npm.
VAN-382