### PR TITLE
feat!: Use the alias edx/brand package.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.3.0",
       "license": "AGPL-3.0",
       "dependencies": {
-        "@edx/brand-edx.org": "2.0.3",
+        "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
         "@openedx/paragon": "^21.13.1",
         "babel-preset-minify": "^0.5.0",
         "classnames": "^2.3.1",
@@ -2956,10 +2956,12 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/@edx/brand-edx.org": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@edx/brand-edx.org/-/brand-edx.org-2.0.3.tgz",
-      "integrity": "sha512-QRmq2su1Xy+9GhY3NRZ+WdjtYWHmgfuKbVCW2skxgfgW9Q6kea8L6LrgigfrZtW+kQq/KdX2tVJcYBkB9xALtQ=="
+    "node_modules/@edx/brand": {
+      "name": "@openedx/brand-openedx",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@openedx/brand-openedx/-/brand-openedx-1.2.3.tgz",
+      "integrity": "sha512-Dn9CtpC8fovh++Xi4NF5NJoeR9yU2yXZnV9IujxIyGd/dn0Phq5t6dzJVfupwq09mpDnzJv7egA8Znz/3ljO+w==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@edx/eslint-config": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "travis-deploy-once": "travis-deploy-once"
   },
   "dependencies": {
-    "@edx/brand-edx.org": "2.0.3",
+    "@edx/brand": "npm:@openedx/brand-openedx@^1.2.2",
     "@openedx/paragon": "^21.13.1",
     "babel-preset-minify": "^0.5.0",
     "classnames": "^2.3.1",

--- a/src/CookiePolicyBanner/_storybook-styles.scss
+++ b/src/CookiePolicyBanner/_storybook-styles.scss
@@ -1,5 +1,5 @@
 /* Base styles the banner assumes are already present when used */
-@import '@edx/brand-edx.org/paragon/fonts';
-@import "@edx/brand-edx.org/paragon/variables";
+@import '@edx/brand/paragon/fonts';
+@import "@edx/brand/paragon/variables";
 
 @import '_cookie-policy-banner.scss';


### PR DESCRIPTION
This repo was not using the `edx/brand` package like most other frontend
repos.  It was instead hardcoded to using the edx.org branding.  This
change updates the repo to default to using the `edx/brand` package
aliased to the `oppenedx/brand-openedx` package by default.

BREAKING CHANGE:  If you wery relying on defults set in the
edx/brand-edx.org package.  You will need to alias the `@edx/brand`
package to `@edx/brand-edx.org` or your own fork of that package.
